### PR TITLE
Fix readme

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ lago::
     $ wget https://path.to.the/repo/repo.metadata
     $ lago init --template-repo-path=repo.metadata ...
 
-Or once with a direct URL::
+Or with a direct URL::
 
     $ lago init \
         --template-repo-path=https://path.to.the/repo/repo.metadata \

--- a/README.rst
+++ b/README.rst
@@ -36,7 +36,7 @@ lago::
     $ wget https://path.to.the/repo/repo.metadata
     $ lago init --template-repo-path=repo.metadata ...
 
-Or once https://bugzilla.redhat.com/show_bug.cgi?id=1288582 is released::
+Or once with a direct URL::
 
     $ lago init \
         --template-repo-path=https://path.to.the/repo/repo.metadata \


### PR DESCRIPTION
The BZ is fixed - one can use a URL definition in the template repo path parameter.