### PR TITLE
Add CirrOS 0.3.5 support

### DIFF
--- a/image-specs/cirros0.3.5-base
+++ b/image-specs/cirros0.3.5-base
@@ -1,0 +1,15 @@
+#base=libguestfs:cirros-0.3.5
+#name=CirrOS 0.3.5
+#osinfo=cirros0.3.5
+#distro=cirros0.3.5
+#arch=x86_64
+#expand=/dev/vda1
+#root-partition=/dev/vda1
+root-password password:123456
+delete /lib/cirros/ds/ec2
+delete /lib/cirros/ds/configdrive
+delete /etc/cirros-init/ds-ec2
+delete /etc/cirros-init/ds-configdrive
+edit /etc/cirros-init/config:'s/DATASOURCE_LIST=.*/DATASOURCE_LIST="nocloud"/g'
+write /bin/bash:/bin/busybox ash
+chmod 111:/bin/bash


### PR DESCRIPTION
1. Disable ec2/cloud-init lookup on boot.
2. Fake 'bash' redirect to 'ash', as the CirrOS busybox is configured
with CONFIG_FEATURE_BASH_IS_NONE=y

Only problem saw so far on boot:
```
Starting logging: OK
modprobe: module virtio_blk not found in modules.dep
modprobe: module virtio_net not found in modules.dep
WARN: /etc/rc3.d/S10-load-modules failed
```

Signed-off-by: Nadav Goldin <ngoldin@redhat.com>