### PR TITLE
locked libvirt-python version to python2 compatible one

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+libvirt-python==5.10.0
 lago
 requests
 future


### PR DESCRIPTION
Libvirt-python is a requirement of Lago. It currently (6.0.0+) only supports python3,
while Lago will stay on python2. Therefore we should lock the version for libvirt-python
to the one that still had python2 support.